### PR TITLE
Replaces a call to sgtk.platform.current_engine with self._app.engine.

### DIFF
--- a/python/tk_multi_importcut/dialog.py
+++ b/python/tk_multi_importcut/dialog.py
@@ -892,7 +892,7 @@ class AppDialog(QtGui.QWidget):
             # Add a watcher to pickup changes only if the app was started from tk-shell
             # usually clients use tk-desktop or tk-shotgun, so it should be safe to
             # assume that this will cause any harm in production
-            if sgtk.platform.current_engine().name == "tk-shell":
+            if self._app.engine.name == "tk-shell":
                 self._css_watcher = QtCore.QFileSystemWatcher([css_file], self)
                 self._css_watcher.fileChanged.connect(self.reload_css)
 


### PR DESCRIPTION
Found this while launching importcut from the post_app_init method in the tk-rv engine. It's not a big deal, but there are phases of initialization on engine and app startup when the sgtk.platform.current_engine global isn't available. Since there's a reference to the parent app in this dialog, it's best to get the engine from there.
