### PR TITLE
37891 jaunt

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,4 +68,4 @@ class ImportCutApp(Application):
         :param frame_rate: The frame rate for the EDL file
         """
         app_payload = self.import_module("tk_multi_importcut")
-        app_payload.dialog.load_edl_for_entity(self, edl_file_path, sg_entity, frame_rate)
+        app_payload.dialog.load_edl_for_entity(self, edl_file_path, sg_entity, float(frame_rate))

--- a/python/tk_multi_importcut/dialog.py
+++ b/python/tk_multi_importcut/dialog.py
@@ -400,10 +400,13 @@ class AppDialog(QtGui.QWidget):
         # Build a list of Entity type / Entity type name tuple
         entity_types = []
         for entity_type in schema_entity_types:
-            entity_types.append((
-                entity_type,
-                self._app.shotgun.schema_entity_read(entity_type)[entity_type]["name"]["value"]
-            ))
+            try:
+                entity_types.append((
+                    entity_type,
+                    self._app.shotgun.schema_entity_read(entity_type)[entity_type]["name"]["value"]
+                ))
+            except:
+                self._logger.info("Entity type %s is not in use, skipping." % entity_type)
         # Sort by the display name
         entity_types.sort(key=itemgetter(1))
         count = len(entity_types)
@@ -502,13 +505,13 @@ class AppDialog(QtGui.QWidget):
         # There is no command line support yet for passing in a base layer
         # media file, so we set mov_file_path to None
         self.new_edl.emit(edl_file_path)
-        if sg_entity:
-            self._selected_sg_entity[_PROJECT_STEP] = self._ctx.project
-            self._selected_sg_entity[_ENTITY_TYPE_STEP] = sg_entity["type"]
-            self.show_entities(sg_entity["type"])
-            self._selected_sg_entity[_ENTITY_STEP] = sg_entity
-            self.show_cuts(sg_entity)
-            self.goto_step(_CUT_STEP)
+        # if sg_entity:
+        #     self._selected_sg_entity[_PROJECT_STEP] = self._ctx.project
+        #     self._selected_sg_entity[_ENTITY_TYPE_STEP] = sg_entity["type"]
+        #     self.show_entities(sg_entity["type"])
+        #     self._selected_sg_entity[_ENTITY_STEP] = sg_entity
+        #     self.show_cuts(sg_entity)
+        #     self.goto_step(_CUT_STEP)
 
     @property
     def no_cut_for_entity(self):

--- a/python/tk_multi_importcut/dialog.py
+++ b/python/tk_multi_importcut/dialog.py
@@ -400,13 +400,10 @@ class AppDialog(QtGui.QWidget):
         # Build a list of Entity type / Entity type name tuple
         entity_types = []
         for entity_type in schema_entity_types:
-            try:
-                entity_types.append((
-                    entity_type,
-                    self._app.shotgun.schema_entity_read(entity_type)[entity_type]["name"]["value"]
-                ))
-            except:
-                self._logger.info("Entity type %s is not in use, skipping." % entity_type)
+            entity_types.append((
+                entity_type,
+                self._app.shotgun.schema_entity_read(entity_type)[entity_type]["name"]["value"]
+            ))
         # Sort by the display name
         entity_types.sort(key=itemgetter(1))
         count = len(entity_types)
@@ -505,6 +502,13 @@ class AppDialog(QtGui.QWidget):
         # There is no command line support yet for passing in a base layer
         # media file, so we set mov_file_path to None
         self.new_edl.emit(edl_file_path)
+
+        # Note: this was useful at one point. We could launch Import Cut from
+        # the command-line directly into the Cut Diff selection step if the link
+        # entity was known. This broke at some point, but there is no current
+        # need for this functionality. Leaving this here for reference since it
+        # probably isn't too difficult to get this working again, if someone
+        # requests it down the line.
         # if sg_entity:
         #     self._selected_sg_entity[_PROJECT_STEP] = self._ctx.project
         #     self._selected_sg_entity[_ENTITY_TYPE_STEP] = sg_entity["type"]

--- a/python/tk_multi_importcut/dialog.py
+++ b/python/tk_multi_importcut/dialog.py
@@ -28,9 +28,10 @@ from .search_widget import SearchWidget
 from .entity_line_widget import EntityLineWidget
 from .extended_thumbnail import ExtendedThumbnail
 
+
 class SelectorButton(QtGui.QPushButton):
     """
-    Thin wrapping class for our selector buttons so styling can be done in the 
+    Thin wrapping class for our selector buttons so styling can be done in the
     style sheet for all of them, using the class name
     """
     pass
@@ -108,6 +109,9 @@ def load_edl_for_entity(app_instance, edl_file_path, sg_entity, frame_rate):
         sg_entity_dict = ast.literal_eval(sg_entity)
         if not isinstance(sg_entity_dict, dict):
             raise ValueError("Invalid SG Entity %s" % sg_entity)
+
+    # Create a settings manager where we can pull and push prefs later.
+    app_instance.user_settings = settings.UserSettings(sgtk.platform.current_bundle())
 
     app_instance.engine.show_dialog(
         "Import Cut",
@@ -387,11 +391,10 @@ class AppDialog(QtGui.QWidget):
         # preferences.
         # Project is systematically added so is always valid
         if(self._preload_entity_type is not None and
-            self._preload_entity_type != "Project" and
-            self._preload_entity_type not in schema_entity_types):
+           self._preload_entity_type != "Project" and
+           self._preload_entity_type not in schema_entity_types):
                 self._logger.warning("Resetting invalid Entity type preference %s" %
-                    self._preload_entity_type
-                )
+                                     self._preload_entity_type)
                 self._preload_entity_type = None
 
         # Build a list of Entity type / Entity type name tuple
@@ -969,7 +972,7 @@ class AppDialog(QtGui.QWidget):
                     "Comparing %s and <b>%s</b> for %s <b>%s</b>" % (
                         os.path.basename(self._processor.edl_file_path),
                         "%s%s" % (self._processor.sg_cut["code"],
-                                     revision_number_str),
+                                  revision_number_str),
                         self._processor.entity_type_name,
                         self._processor.entity_name,
                     )

--- a/python/tk_multi_importcut/edl_cut.py
+++ b/python/tk_multi_importcut/edl_cut.py
@@ -34,16 +34,16 @@ _ERROR_BAD_CUT = (
 )
 
 # A string we add at the end of the standard editorial fw error message
-_ERROR_FRAME_RATE_ADD_ON = ( "You can modify the frame rate used by Import Cut by "
-"clicking on the Settings button and going to the Timecode/Frames tab." )
+_ERROR_FRAME_RATE_ADD_ON = ("You can modify the frame rate used by Import Cut by "
+"clicking on the Settings button and going to the Timecode/Frames tab.")
 
-_ERROR_BL = ( "This edl has a black slug (BL) event. Currently, the Import Cut app "
+_ERROR_BL = ("This edl has a black slug (BL) event. Currently, the Import Cut app "
 "will not accept EDLs with these events. Support for black slug (BL) events "
-"will be added in a future release." )
+"will be added in a future release.")
 
-_ERROR_DROP_FRAME = ( "This edl uses drop frame timecode. Currently, the Import Cut "
+_ERROR_DROP_FRAME = ("This edl uses drop frame timecode. Currently, the Import Cut "
 "app only accepts EDLs with non-drop frame timecode. Support for drop timecode "
-"will be added in a future release." )
+"will be added in a future release.")
 
 
 def get_sg_entity_name(sg_entity):
@@ -215,6 +215,10 @@ class EdlCut(QtCore.QObject):
         edit.get_shot_name = lambda: edit._shot_name
         edit.get_clip_name = lambda: edit._clip_name
         edit.get_sg_version = lambda: edit._sg_version
+        edit.get_transition_in = lambda: edit._transition_in
+
+        # self._logger.info(edit._transition_in)
+
         # In this app, the convention is that clip names hold Version names
         # which is not the case for other apps like tk-multi-importscan
         # where the Version name is set with locators and clip name is used
@@ -1540,6 +1544,8 @@ class EdlCut(QtCore.QObject):
                             "cut_item_out": cut_diff.new_cut_out,
                             "edit_in": edit_in,
                             "edit_out": edit_out,
+                            # "edit_in_no_transition": 1,
+                            # "edit_out_no_transition": 2,
                             "cut_item_duration": cut_diff.new_cut_out - cut_diff.new_cut_in + 1,
                             "shot": cut_diff.sg_shot,
                             "version": cut_diff.sg_version,

--- a/python/tk_multi_importcut/user_settings.py
+++ b/python/tk_multi_importcut/user_settings.py
@@ -32,6 +32,7 @@ class UserSetting(object):
         self._default = default
         self._affects = affects or []
 
+
 class UserSettings(object):
     """
     Class for retrieving and managing User Settings.


### PR DESCRIPTION
Same comment as the PR #8 for tk-framework-editorial:

The jaunt_in/out points live inside the cut_in/cut_out points. When transitions are present, cut_in/cut_out essentially become transition_in/transition_out. So these extra jaunt_in/out points, in that case, represent the original cut_in/cut_out points. If we want to keep this functionality as part of tk-multi-importcut and not fork this repo for Jaunt, perhaps we should rename jaunt_in/out to orig_cut_in/out or something similar. However, this is a hack and true support for transitions will most likely use a different approach, so maybe it is a good idea to fork the repo anyway. Opinions?
