### PR TITLE
for #40161: support drop frame in relative and absolute offset settings

### DIFF
--- a/python/tk_multi_importcut/cut_diff.py
+++ b/python/tk_multi_importcut/cut_diff.py
@@ -199,6 +199,8 @@ class CutDiff(QtCore.QObject):
         default_frame_rate = float(user_settings.retrieve("default_frame_rate"))
 
         # If we have an edit, ensure our mapping timecodes match the drop frame setting.
+        # Note that these settings are retrieved for each new import in order to ensure
+        # that we respect the drop frame settings for every new EDL.
         edit_drop_frame = False
         if self.edit:
             edit_drop_frame = self.edit.drop_frame


### PR DESCRIPTION
Ensures the offset settings inherit the drop frame setting of the current edit if there is one. 

When using relative mode, this will check to see if there is a conflict between the edit drop frame setting and the drop frame setting implied by the notation of the timecode (using a `;`). While this is not currently possible due to the fact that the UI masks the input so the user is only inputting numbers and not the delimiters, the code is in place to handle this should we open this up in the future.