### PR TITLE
Fix EDL Cut read only image_source_entity issue

### DIFF
--- a/python/tk_multi_importcut/edl_cut.py
+++ b/python/tk_multi_importcut/edl_cut.py
@@ -505,7 +505,8 @@ class EdlCut(QtCore.QObject):
                 # General lookup
                 for field_name, field in shot_schema.iteritems():
                     if field["data_type"]["value"] == "entity":
-                        if self._sg_entity_type in field["properties"]["valid_types"]["value"]:
+                        if (self._sg_entity_type in field["properties"]["valid_types"]["value"] and
+                                field["editable"]["value"] is True):
                             self._sg_shot_link_field_name = field_name
                             break
             if not self._sg_shot_link_field_name:


### PR DESCRIPTION
This commit is a fix for RV Import Cut Tries to write to "image_source_entity" field when crating New Shots.

Problem:
This issue began to appear with Shotgun version 7.12.0.0 (r5842013).
This is where the read-only image_source_entity was added.
Stephane Daigle (thank you Stephane!) investigated this issue and he found the root cause:

<<When the import cut has to create a Shot it tries to link it to the Episode or Sequence in which the Shot is created.
To do this, it first looks for a field called 'sg_episode' (or 'sg_sequence').
If that field cannot be found, it goes through all the fields of the Shot entity and tries to find an entity field that can be linked to an Episode (or Sequence).
This is where it falls on the image_source_entity field (which is an entity field that can basically be linked to any entity type).
The problem is that the code does not check to see if this field is a read-only field.>>

The problem is that the "_sg_shot_link_field_name" is initialized to be the 'image_source_entity' field because this is an entity field that accepts "Episode" entity types. The code should include a test to see if the field is read-only or not before choosing it. Since 'image_source_entity' is read-only, it would be ignored (as it should!).

Solution:
Fix the code to verify if it is a read-only before trying writing to it.

JIRA: SG-9016