### PR TITLE
Fixes columnSpan for modern PySide2

### DIFF
--- a/python/tk_multi_importcut/cuts_view.py
+++ b/python/tk_multi_importcut/cuts_view.py
@@ -87,7 +87,7 @@ class CutsView(QtCore.QObject):
             column,
         )
         self._grid_layout.setRowStretch(row, 0)
-        self._grid_layout.addItem(spacer, row + 1, 0, colSpan=2)
+        self._grid_layout.addItem(spacer, row + 1, 0, columnSpan=2)
         self._grid_layout.setRowStretch(row + 1, 1)
         self._info_message = (
             ("%d Cuts" % (i + 1)) if (i + 1) > 1 else ("%d Cut" % (i + 1))
@@ -205,7 +205,7 @@ class CutsView(QtCore.QObject):
             self._grid_layout.setRowStretch(row, 0)
 
         # Put back the stretcher
-        self._grid_layout.addItem(spacer, row + 1, 0, colSpan=2)
+        self._grid_layout.addItem(spacer, row + 1, 0, columnSpan=2)
         self._grid_layout.setRowStretch(row + 1, 1)
         # And update the menu label
         self._sort_menu_button.setText(action.text())

--- a/python/tk_multi_importcut/entities_view.py
+++ b/python/tk_multi_importcut/entities_view.py
@@ -110,7 +110,7 @@ class EntitiesView(QtCore.QObject):
         )
         self._grid_layout.setRowStretch(row, 0)
         # Put the stretcher back
-        self._grid_layout.addItem(spacer, row + 1, 0, colSpan=2)
+        self._grid_layout.addItem(spacer, row + 1, 0, columnSpan=2)
         self._grid_layout.setRowStretch(row + 1, 1)
         count = i + 1
         self._info_message = (
@@ -210,7 +210,7 @@ class EntitiesView(QtCore.QObject):
             self._grid_layout.setRowStretch(row, 0)
 
         # Put back the stretcher
-        self._grid_layout.addItem(spacer, row + 1, 0, colSpan=2)
+        self._grid_layout.addItem(spacer, row + 1, 0, columnSpan=2)
         self._grid_layout.setRowStretch(row + 1, 1)
         # Avoid flashes and jittering by resizing the grid widget to a size
         # suitable to hold all cards

--- a/python/tk_multi_importcut/projects_view.py
+++ b/python/tk_multi_importcut/projects_view.py
@@ -82,7 +82,7 @@ class ProjectsView(QtCore.QObject):
         )
         self._grid_layout.setRowStretch(row, 0)
         # Put the stretcher back
-        self._grid_layout.addItem(spacer, row + 1, 0, colSpan=2)
+        self._grid_layout.addItem(spacer, row + 1, 0, columnSpan=2)
         self._grid_layout.setRowStretch(row + 1, 1)
         count = i + 1
         self._info_message = (
@@ -182,7 +182,7 @@ class ProjectsView(QtCore.QObject):
             self._grid_layout.setRowStretch(row, 0)
 
         # Put back the stretcher
-        self._grid_layout.addItem(spacer, row + 1, 0, colSpan=2)
+        self._grid_layout.addItem(spacer, row + 1, 0, columnSpan=2)
         self._grid_layout.setRowStretch(row + 1, 1)
         # Avoid flashes and jittering by resizing the grid widget to a size
         # suitable to hold all cards


### PR DESCRIPTION
According Qt 5.15 LTS documentation, colSpan should have been named columnSpan.
https://doc.qt.io/qt-5/qgridlayout.html#addItem

It seems to be the same on the older 5.6.
https://devdocs.io/qt~5.6/qgridlayout#addItem
