### PR TITLE
SG-39259 Fix pyside regex syntax issue on pyside6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ exclude: "resources/*|ui\/.*py"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -37,7 +37,7 @@ repos:
     - id: check-yaml
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 26.1.0
     hooks:
     - id: black
       language_version: python3

--- a/python/tk_multi_importcut/cut_diff_widget.py
+++ b/python/tk_multi_importcut/cut_diff_widget.py
@@ -21,7 +21,6 @@ from .constants import _COLORS
 # the code will be compatible with both PySide and PyQt.
 from sgtk.platform.qt import QtCore, QtGui
 
-
 edl = sgtk.platform.import_framework("tk-framework-editorial", "edl")
 
 # diff_type property values which are set on the widget

--- a/python/tk_multi_importcut/edl_cut.py
+++ b/python/tk_multi_importcut/edl_cut.py
@@ -1075,7 +1075,7 @@ class EdlCut(QtCore.QObject):
 
         return score
 
-    @QtCore.Slot(str, dict, dict, str, bool)
+    @QtCore.Slot(str, dict, list, str, bool)
     def do_cut_import(self, u_title, sender, to, u_description, update_shots):
         """
         Import the Cut changes in Flow Production Tracking
@@ -1088,7 +1088,7 @@ class EdlCut(QtCore.QObject):
         :param u_title: A unicode string, the new PTR Cut name and a title for the Note
                       that will be created
         :param sender: A PTR user dictionary, the Note sender
-        :param to: A PTR Group dictionary, the recipient for the Note
+        :param to: A list of PTR Group dictionaries, the recipients for the Note
         :param u_description: Comments as a unicode string, used in the Note's body
         :param update_shots: A boolean, whether or not existing Shots data will
                              be updated
@@ -1131,7 +1131,7 @@ class EdlCut(QtCore.QObject):
 
         :param title: A string, the Note title
         :param sender: A Flow Production Tracking user dictionary
-        :param to: A Flow Production Tracking Group dictionary
+        :param to: A list of Flow Production Tracking Group dictionaries, the recipients for the Note
         :param description: Some comments which will be added to the Note
         :param sg_links: Optional list of Flow Production Tracking Entity dictionaries to link the note to
         """

--- a/python/tk_multi_importcut/entity_line_widget.py
+++ b/python/tk_multi_importcut/entity_line_widget.py
@@ -52,8 +52,13 @@ class EntityLineWidget(QtGui.QLineEdit):
         completer.setCaseSensitivity(QtCore.Qt.CaseInsensitive)
         self.setCompleter(completer)
         # Only allow alpha numeric characters, _ and -
-        rx = QtCore.QRegExp("[\w-]*")
-        self.setValidator(QtGui.QRegExpValidator(rx, self))
+        # Use QRegularExpressionValidator for PySide6, QRegExpValidator for PySide2
+        if hasattr(QtCore, "QRegularExpression"):
+            rx = QtCore.QRegularExpression(r"[\w-]*")
+            self.setValidator(QtGui.QRegularExpressionValidator(rx, self))
+        else:
+            rx = QtCore.QRegExp(r"[\w-]*")
+            self.setValidator(QtGui.QRegExpValidator(rx, self))
         self.set_property("valid", True)
         # Just a way to be warned when the value was edited
         self.editingFinished.connect(self.edited)

--- a/python/tk_multi_importcut/processor.py
+++ b/python/tk_multi_importcut/processor.py
@@ -60,7 +60,7 @@ class Processor(QtCore.QThread):
     got_busy = QtCore.Signal(int)
     got_idle = QtCore.Signal()
     progress_changed = QtCore.Signal(int)
-    import_cut = QtCore.Signal(str, dict, dict, str, bool)
+    import_cut = QtCore.Signal(str, dict, list, str, bool)
     totals_changed = QtCore.Signal()
     delete_cut_diff = QtCore.Signal(CutDiff)
     ready = QtCore.Signal()

--- a/python/tk_multi_importcut/settings_dialog.py
+++ b/python/tk_multi_importcut/settings_dialog.py
@@ -475,14 +475,14 @@ class SettingsDialog(QtGui.QDialog):
 
         if not self.ui.default_head_duration_line_edit.hasAcceptableInput():
             raise SettingsError("Default Head Duration must be set")
-        new_values["default_head_duration"] = (
-            self.ui.default_head_duration_line_edit.text()
-        )
+        new_values[
+            "default_head_duration"
+        ] = self.ui.default_head_duration_line_edit.text()
         if not self.ui.default_tail_duration_line_edit.hasAcceptableInput():
             raise SettingsError("Default Tail Duration must be set")
-        new_values["default_tail_duration"] = (
-            self.ui.default_tail_duration_line_edit.text()
-        )
+        new_values[
+            "default_tail_duration"
+        ] = self.ui.default_tail_duration_line_edit.text()
 
         # Retrieve a list of wizard steps potentially affected by these changes
         affected = self._user_settings.reset_needed(new_values, self._wizard_step)

--- a/python/tk_multi_importcut/settings_dialog.py
+++ b/python/tk_multi_importcut/settings_dialog.py
@@ -38,8 +38,10 @@ field is empty, the Default Head In value set below for New Shots will be used."
 _RELATIVE_INSTRUCTIONS = "In Relative mode, the app will map the timecode \
 values from the EDL to frames based on a specific timecode/frame relationship."
 
-_BAD_GROUP_MSG = '"%s" does not match a valid Group in Flow Production Tracking. Please enter \
+_BAD_GROUP_MSG = (
+    '"%s" does not match a valid Group in Flow Production Tracking. Please enter \
 another Group or create "%s" in Flow Production Tracking to proceed.'
+)
 
 _BAD_STATUS_MSG = "The following statuses for reinstating Shots do not match \
 valid statuses in Flow Production Tracking:\n\n%s\n\nPlease enter another status to proceed."
@@ -475,14 +477,14 @@ class SettingsDialog(QtGui.QDialog):
 
         if not self.ui.default_head_duration_line_edit.hasAcceptableInput():
             raise SettingsError("Default Head Duration must be set")
-        new_values[
-            "default_head_duration"
-        ] = self.ui.default_head_duration_line_edit.text()
+        new_values["default_head_duration"] = (
+            self.ui.default_head_duration_line_edit.text()
+        )
         if not self.ui.default_tail_duration_line_edit.hasAcceptableInput():
             raise SettingsError("Default Tail Duration must be set")
-        new_values[
-            "default_tail_duration"
-        ] = self.ui.default_tail_duration_line_edit.text()
+        new_values["default_tail_duration"] = (
+            self.ui.default_tail_duration_line_edit.text()
+        )
 
         # Retrieve a list of wizard steps potentially affected by these changes
         affected = self._user_settings.reset_needed(new_values, self._wizard_step)

--- a/python/tk_multi_importcut/submit_dialog.py
+++ b/python/tk_multi_importcut/submit_dialog.py
@@ -25,7 +25,7 @@ class SubmitDialog(QtGui.QDialog):
     Submit dialog, offering a summary and a couple of options to the user
     """
 
-    submit = QtCore.Signal(str, dict, dict, str, bool)
+    submit = QtCore.Signal(str, dict, list, str, bool)
 
     def __init__(self, parent=None, title=None, summary=None):
         """


### PR DESCRIPTION
## Problem

Using the Import Cut Tool from Desktop app, the last step "Summary Page" is not loading correctly. The final 'summary' stage page in the wizard, does not propagate any additional shot details etc in the UI which we would expect to see.

## Root cause and fix

`QRegExpValidator` has been removed because `QRegExp` itself is deprecated in Qt 6. The replacement is `QRegularExpressionValidator` with `QRegularExpression`.

This causes the following error reported on the console.

<img width="1496" height="678" alt="Screenshot 2026-02-11 at 1 13 26 PM" src="https://github.com/user-attachments/assets/204517c8-8970-4a71-ac77-0327e12532db" />


For this PR, I did something similar to https://github.com/shotgunsoftware/tk-multi-workfiles2/pull/166/changes/a6bf78c16e6c43d479bac6acf46488a0a09eadaa.

## Testing

| Description | Screenshot |
--|--
|`TestGroup1` Group created on the project | <img width="746" height="407" alt="image" src="https://github.com/user-attachments/assets/b0e6fbdd-d977-44d0-a572-6818532f801d" />|
|Note created and sent to `TestGroup1` |  <img width="1054" height="688" alt="image" src="https://github.com/user-attachments/assets/5561cfdf-c5cb-4141-aad1-f366b1bd71fa" />|
|Cut published by importcut app |  <img width="1046" height="500" alt="image" src="https://github.com/user-attachments/assets/504bd31d-8373-4aca-a1d9-0920b008d161" />|



## Side-quest

An error has been reported from the logs that we thought was the root cause:

```
tank_vendor.shotgun_api3.shotgun.Fault: API create() Note.addressings_to expected [Array] data type(s) but got Hash:
{}
```

To fix this, I changed the data type of the PySide signal from `dict` to `list`, which is expected by FPT api.