### PR TITLE
SG-43664 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     - id: check-yaml
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -33,6 +33,7 @@ description: "An app to import Cut changes."
 requires_shotgun_version: v7.0.0
 requires_core_version: "v0.16.18"
 requires_engine_version:
+minimum_python_version: "3.9"
 
 documentation_url: "https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Editorial_ed_import_cut_depth_html"
 

--- a/python/tk_multi_importcut/extended_thumbnail.py
+++ b/python/tk_multi_importcut/extended_thumbnail.py
@@ -51,7 +51,7 @@ class ExtendedThumbnail(QtGui.QLabel):
 
         :param event: A QEvent
         """
-        super(ExtendedThumbnail, self).paintEvent(event)
+        super().paintEvent(event)
         painter = QtGui.QPainter()
         try:
             painter.begin(self)

--- a/python/tk_multi_importcut/logger.py
+++ b/python/tk_multi_importcut/logger.py
@@ -85,7 +85,7 @@ class BundleLogHandler(logging.StreamHandler):
         :param args: Arbitrary list of parameters used in base class init
         :param kwargs: Arbitrary dictionary of parameters used in base class init
         """
-        super(BundleLogHandler, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._bundle = bundle
         self._qt_emitter = self._QtEmitter()
 


### PR DESCRIPTION
## Summary
- Set `minimum_python_version: "3.9"` in `info.yml`
- Modernised `super()` calls in `extended_thumbnail.py` and `logger.py`

## Test plan
- [ ] Pre-commit passes (black, check-ast, check-yaml, whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)